### PR TITLE
ISSUE-5 Provide tool to show state operator information from existing checkpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The features we provide as of now are:
 * Create savepoint from existing checkpoint of Structured Streaming query
   * You can pick specific batch (if it exists on metadata) to create savepoint.
   * With feature of writing state, you can achieve rescaling state, simple schema evolution, etc.
+* Show state operator information in checkpoint which you'll need to provide to enjoy above features
 
 As this project leverages Spark Structured Streaming's interfaces, and doesn't deal with internal
 (e.g. the structure of state file for HDFS state store), the performance may be suboptimal.
@@ -33,6 +34,26 @@ Spark 2.4.x is supported: it only means you should link Spark 2.4.x when using t
 ## How to use
 
 FIXME: Adding artifact to your project will be described here when the artifact is published to Maven central.
+
+First of all, you may want to get state and last batch information to provide them as parameters.
+You can get it from `StateInformationInCheckpoint`, whether calling from your codebase or running with `spark-submit`.
+Here we assume you have artifact jar of spark-state-tool and you want to run it from cli (leveraging `spark-submit`).
+
+```text
+<spark_path>/bin/spark-submit --master "local[*]" \
+--class org.apache.spark.sql.state.StateInformationInCheckpoint \
+spark-state-tool-0.0.1-SNAPSHOT.jar <checkpoint_root_path>
+```
+
+The command line will provide checkpoint information like below:
+
+```text
+Last committed batch ID: 2
+Operator ID: 0, partitions: 5, storeNames: List(default)
+```
+
+This output means the query has batch ID 2 as last committed (NOTE: corresponding state version is 3, not 2), and
+there's only one stateful operator which has ID as 0, and 5 partitions, and there's also only one kind of store named "default".
 
 To read state from your existing query, you can start your batch query like:
 

--- a/src/main/scala/org/apache/spark/sql/HadoopPathUtil.scala
+++ b/src/main/scala/org/apache/spark/sql/HadoopPathUtil.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Jungtaek Lim "<kabhwan@gmail.com>"
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+
+object HadoopPathUtil {
+  def resolve(hadoopConf: Configuration, cpLocation: String): String = {
+    val checkpointPath = new Path(cpLocation)
+    val fs = checkpointPath.getFileSystem(hadoopConf)
+    checkpointPath.makeQualified(fs.getUri, fs.getWorkingDirectory).toUri.toString
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/checkpoint/CheckpointUtil.scala
+++ b/src/main/scala/org/apache/spark/sql/checkpoint/CheckpointUtil.scala
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.state
+package org.apache.spark.sql.checkpoint
 
 import org.apache.hadoop.fs.{FileUtil, Path}
 
+import org.apache.spark.sql.HadoopPathUtil
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.streaming.{CommitLog, OffsetSeqLog}
 import org.apache.spark.sql.internal.SQLConf
@@ -33,15 +34,9 @@ object CheckpointUtil {
       excludeState: Boolean = false): Unit = {
     val hadoopConf = sparkSession.sessionState.newHadoopConf()
 
-    def resolve(cpLocation: String): String = {
-      val checkpointPath = new Path(cpLocation)
-      val fs = checkpointPath.getFileSystem(hadoopConf)
-      checkpointPath.makeQualified(fs.getUri, fs.getWorkingDirectory).toUri.toString
-    }
-
-    val src = new Path(resolve(checkpointRoot))
+    val src = new Path(HadoopPathUtil.resolve(hadoopConf, checkpointRoot))
     val srcFs = src.getFileSystem(hadoopConf)
-    val dst = new Path(resolve(newCheckpointRoot))
+    val dst = new Path(HadoopPathUtil.resolve(hadoopConf, newCheckpointRoot))
     val dstFs = dst.getFileSystem(hadoopConf)
 
     if (dstFs.listFiles(dst, false).hasNext) {

--- a/src/main/scala/org/apache/spark/sql/state/StateInformationInCheckpoint.scala
+++ b/src/main/scala/org/apache/spark/sql/state/StateInformationInCheckpoint.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2019 Jungtaek Lim "<kabhwan@gmail.com>"
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.state
+
+import scala.util.Try
+
+import org.apache.hadoop.fs.{FileStatus, Path, PathFilter}
+
+import org.apache.spark.sql.{HadoopPathUtil, SparkSession}
+import org.apache.spark.sql.execution.streaming.CommitLog
+import org.apache.spark.sql.execution.streaming.state.StateStoreId
+
+class StateInformationInCheckpoint(spark: SparkSession) {
+  import org.apache.spark.sql.state.StateInformationInCheckpoint._
+
+  val hadoopConf = spark.sessionState.newHadoopConf()
+
+  def gatherInformation(checkpointPath: Path): StateInformation = {
+    val commitLog = new CommitLog(spark, new Path(checkpointPath, "commits").toString)
+    val lastCommittedBatchId = commitLog.getLatest() match {
+      case Some((lastId, _)) => lastId
+      case None => -1
+    }
+
+    if (lastCommittedBatchId < 0) {
+      return StateInformation(None, Seq.empty)
+    }
+
+    val fs = checkpointPath.getFileSystem(hadoopConf)
+    val numericDirectories = new PathFilter() {
+      override def accept(path: Path): Boolean = {
+        fs.isDirectory(path) && Try(path.getName.toInt).isSuccess && path.getName.toInt >= 0
+      }
+    }
+
+    val statePath = new Path(checkpointPath, "state")
+    val operatorDirs = fs.listStatus(statePath, numericDirectories)
+
+    val opInfos = operatorDirs.map { operatorDir =>
+      val opPath = operatorDir.getPath
+      val opId = opPath.getName.toInt
+
+      val partitions = fs.listStatus(opPath, numericDirectories)
+      if (partitions.nonEmpty) {
+        validateCorrectPartitions(partitions)
+
+        // assuming information is same across partitions
+        val partitionDir = partitions.head
+
+        val statuses = fs.listStatus(partitionDir.getPath)
+        val dirs = statuses.filter(status => fs.isDirectory(status.getPath))
+        val storeNames = if (dirs.nonEmpty) {
+          dirs.map(_.getPath.getName).toList
+        } else {
+          // assuming default store name
+          List(StateStoreId.DEFAULT_STORE_NAME)
+        }
+
+        StateOperatorInformation(opId, partitions.length, storeNames)
+      } else {
+        StateOperatorInformation(opId, 0, Seq.empty)
+      }
+    }
+
+    StateInformation(Some(lastCommittedBatchId), opInfos)
+  }
+
+  private def validateCorrectPartitions(partitions: Array[FileStatus]): Unit = {
+    val partitionsSorted = partitions.sortBy(fs => fs.getPath.getName.toInt)
+    val partitionNums = partitionsSorted.map(_.getPath.getName.toInt)
+    // assuming no same number - they're directories hence no same name
+    val head = partitionNums.head
+    val tail = partitionNums(partitionNums.length - 1)
+    assert(head == 0, "Partition should start with 0")
+    assert((tail - head + 1) == partitionNums.length,
+      s"No continuous partitions in state: $partitionNums")
+  }
+}
+
+object StateInformationInCheckpoint {
+
+  case class StateOperatorInformation(opId: Int, partitions: Int, storeNames: Seq[String])
+  case class StateInformation(
+      lastCommittedBatchId: Option[Long],
+      operators: Seq[StateOperatorInformation])
+
+  // scalastyle:off println
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession
+      .builder
+      .appName("StateInformationInCheckpoint")
+      .getOrCreate()
+
+    if (args.length < 1) {
+      System.err.println("Usage: StateInformationInCheckpoint [checkpoint path]")
+      sys.exit(1)
+    }
+
+    val checkpointRoot = args(0)
+
+    println(s"Checkpoint path: $checkpointRoot")
+
+    val hadoopConf = spark.sessionState.newHadoopConf()
+    val checkpointPath = new Path(HadoopPathUtil.resolve(hadoopConf, checkpointRoot))
+    val fs = checkpointPath.getFileSystem(hadoopConf)
+
+    if (!fs.exists(checkpointPath) || !fs.isDirectory(checkpointPath)) {
+      System.err.println("Checkpoint path doesn't exist or not a directory.")
+      sys.exit(2)
+    }
+
+    val stateInfo = new StateInformationInCheckpoint(spark).gatherInformation(checkpointPath)
+
+    stateInfo.lastCommittedBatchId match {
+      case Some(lastId) =>
+        println(s"Last committed batch ID: $lastId")
+        stateInfo.operators.foreach { op =>
+          println(s"Operator ID: ${op.opId}, partitions: ${op.partitions}, " +
+            s"storeNames: ${op.storeNames}")
+        }
+
+      case None => println("No batch has been committed.")
+    }
+  }
+  // scalastyle:on println
+}

--- a/src/main/scala/org/apache/spark/sql/state/StateStoreReaderRDD.scala
+++ b/src/main/scala/org/apache/spark/sql/state/StateStoreReaderRDD.scala
@@ -94,6 +94,7 @@ class StateStoreReaderRDD(
       // assuming no same number - they're directories hence no same name
       val head = partitionNums.head
       val tail = partitionNums(partitionNums.length - 1)
+      assert(head == 0, "Partition should start with 0")
       assert((tail - head + 1) == partitionNums.length,
         s"No continuous partitions in state: $partitionNums")
 

--- a/src/test/scala/org/apache/spark/sql/state/StateInformationInCheckpointSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/state/StateInformationInCheckpointSuite.scala
@@ -79,7 +79,7 @@ class StateInformationInCheckpointSuite
       assert(operator.opId === 0)
       assert(operator.partitions === spark.sqlContext.conf.numShufflePartitions)
       // NOTE: this verification couples with implementation details of streaming join
-      assert(operator.storeNames === Seq("left-keyToNumValues", "left-keyWithIndexToValue",
+      assert(operator.storeNames.toSet === Set("left-keyToNumValues", "left-keyWithIndexToValue",
         "right-keyToNumValues", "right-keyWithIndexToValue"))
     }
   }

--- a/src/test/scala/org/apache/spark/sql/state/StateInformationInCheckpointSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/state/StateInformationInCheckpointSuite.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2019 Jungtaek Lim "<kabhwan@gmail.com>"
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.state
+
+import org.apache.hadoop.fs.Path
+import org.scalatest.{Assertions, BeforeAndAfterAll}
+
+import org.apache.spark.sql.execution.streaming.state.{StateStore, StateStoreId}
+
+class StateInformationInCheckpointSuite
+  extends StateStoreTest
+  with BeforeAndAfterAll
+  with Assertions {
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    StateStore.stop()
+  }
+
+  test("Reading checkpoint from streaming aggregation") {
+    withTempDir { cpDir =>
+      runCompositeKeyStreamingAggregationQuery(cpDir.getAbsolutePath)
+
+      val stateInfo = new StateInformationInCheckpoint(spark)
+        .gatherInformation(new Path(cpDir.getAbsolutePath))
+
+      assert(stateInfo.lastCommittedBatchId === Some(2))
+      assert(stateInfo.operators.length === 1)
+
+      val operator = stateInfo.operators.head
+      assert(operator.opId === 0)
+      assert(operator.partitions === spark.sqlContext.conf.numShufflePartitions)
+      assert(operator.storeNames === Seq(StateStoreId.DEFAULT_STORE_NAME))
+    }
+  }
+
+  test("Reading checkpoint from streaming deduplication") {
+    withTempDir { cpDir =>
+      runStreamingDeduplicationQuery(cpDir.getAbsolutePath)
+
+      val stateInfo = new StateInformationInCheckpoint(spark)
+        .gatherInformation(new Path(cpDir.getAbsolutePath))
+
+      assert(stateInfo.lastCommittedBatchId === Some(2))
+      assert(stateInfo.operators.length === 1)
+
+      val operator = stateInfo.operators.head
+      assert(operator.opId === 0)
+      assert(operator.partitions === spark.sqlContext.conf.numShufflePartitions)
+      assert(operator.storeNames === Seq(StateStoreId.DEFAULT_STORE_NAME))
+    }
+  }
+
+  test("Reading checkpoint from streaming join") {
+    withTempDir { cpDir =>
+      runStreamingJoinQuery(cpDir.getAbsolutePath)
+
+      val stateInfo = new StateInformationInCheckpoint(spark)
+        .gatherInformation(new Path(cpDir.getAbsolutePath))
+
+      assert(stateInfo.lastCommittedBatchId === Some(1))
+      assert(stateInfo.operators.length === 1)
+
+      val operator = stateInfo.operators.head
+      assert(operator.opId === 0)
+      assert(operator.partitions === spark.sqlContext.conf.numShufflePartitions)
+      // NOTE: this verification couples with implementation details of streaming join
+      assert(operator.storeNames === Seq("left-keyToNumValues", "left-keyWithIndexToValue",
+        "right-keyToNumValues", "right-keyWithIndexToValue"))
+    }
+  }
+
+  test("Reading checkpoint from flatMapGroupsWithState") {
+    withTempDir { cpDir =>
+      runFlatMapGroupsWithStateQuery(cpDir.getAbsolutePath)
+
+      val stateInfo = new StateInformationInCheckpoint(spark)
+        .gatherInformation(new Path(cpDir.getAbsolutePath))
+
+      assert(stateInfo.lastCommittedBatchId === Some(1))
+      assert(stateInfo.operators.length === 1)
+
+      val operator = stateInfo.operators.head
+      assert(operator.opId === 0)
+      assert(operator.partitions === spark.sqlContext.conf.numShufflePartitions)
+      assert(operator.storeNames === Seq(StateStoreId.DEFAULT_STORE_NAME))
+    }
+  }
+}

--- a/src/test/scala/org/apache/spark/sql/state/StateStoreStreamingAggregationWriteSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/state/StateStoreStreamingAggregationWriteSuite.scala
@@ -22,6 +22,7 @@ import org.scalatest.{Assertions, BeforeAndAfterAll}
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes.Update
+import org.apache.spark.sql.checkpoint.CheckpointUtil
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.execution.streaming.state.StateStore
 import org.apache.spark.sql.internal.SQLConf


### PR DESCRIPTION
This patch introduces `StateInformationInCheckpoint` which can be run with `spark-submit` to show below informations:

- Last "committed" batch ID
- ID, number of partitions, store names per operator

The example of how to run tool is below:

```
<spark_path>/bin/spark-submit --master "local[*]" \
--class org.apache.spark.sql.state.StateInformationInCheckpoint \
spark-state-tool-0.0.1-SNAPSHOT.jar <checkpoint_root_path>
```

The example of output is below:

```
Last committed batch ID: 2
Operator ID: 0, partitions: 5, storeNames: List(default)
```

As of now Structured Streaming doesn't support multiple aggregations, so mostly there's only one operator in streaming query.

Closes #5 