### PR TITLE
ISSUE-13 Support migration on streaming aggregation state format 1 to 2

### DIFF
--- a/src/main/scala/org/apache/spark/sql/SchemaUtil.scala
+++ b/src/main/scala/org/apache/spark/sql/SchemaUtil.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Jungtaek Lim "<kabhwan@gmail.com>"
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.types.{DataType, StructType}
+
+object SchemaUtil {
+  def getSchemaAsDataType(schema: StructType, fieldName: String): DataType = {
+    schema(schema.getFieldIndex(fieldName).get).dataType
+  }
+}

--- a/src/main/scala/org/apache/spark/sql/state/StateStoreDataSourceProvider.scala
+++ b/src/main/scala/org/apache/spark/sql/state/StateStoreDataSourceProvider.scala
@@ -16,7 +16,7 @@
 
 package org.apache.spark.sql.state
 
-import org.apache.spark.sql.{AnalysisException, DataFrame, SaveMode, SQLContext}
+import org.apache.spark.sql._
 import org.apache.spark.sql.execution.streaming.state.StateStoreId
 import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, DataSourceRegister, SchemaRelationProvider}
 import org.apache.spark.sql.types.{DataType, StructType}
@@ -41,8 +41,8 @@ class StateStoreDataSourceProvider
         "and each field should have corresponding fields (they should be a StructType)")
     }
 
-    val keySchema = getSchemaAsDataType(schema, "key").asInstanceOf[StructType]
-    val valueSchema = getSchemaAsDataType(schema, "value").asInstanceOf[StructType]
+    val keySchema = SchemaUtil.getSchemaAsDataType(schema, "key").asInstanceOf[StructType]
+    val valueSchema = SchemaUtil.getSchemaAsDataType(schema, "value").asInstanceOf[StructType]
 
     val checkpointLocation = parameters.get(PARAM_CHECKPOINT_LOCATION) match {
       case Some(cpLocation) => cpLocation
@@ -110,8 +110,8 @@ class StateStoreDataSourceProvider
         "and each field should have corresponding fields (they should be a StructType)")
     }
 
-    val keySchema = getSchemaAsDataType(data.schema, "key").asInstanceOf[StructType]
-    val valueSchema = getSchemaAsDataType(data.schema, "value").asInstanceOf[StructType]
+    val keySchema = SchemaUtil.getSchemaAsDataType(data.schema, "key").asInstanceOf[StructType]
+    val valueSchema = SchemaUtil.getSchemaAsDataType(data.schema, "value").asInstanceOf[StructType]
 
     new StateStoreWriter(sqlContext.sparkSession, data, keySchema, valueSchema, checkpointLocation,
       version, operatorId, storeName, newPartitions).write()
@@ -123,17 +123,13 @@ class StateStoreDataSourceProvider
   private def isValidSchema(schema: StructType): Boolean = {
     if (schema.fieldNames.toSeq != Seq("key", "value")) {
       false
-    } else if (!getSchemaAsDataType(schema, "key").isInstanceOf[StructType]) {
+    } else if (!SchemaUtil.getSchemaAsDataType(schema, "key").isInstanceOf[StructType]) {
       false
-    } else if (!getSchemaAsDataType(schema, "value").isInstanceOf[StructType]) {
+    } else if (!SchemaUtil.getSchemaAsDataType(schema, "value").isInstanceOf[StructType]) {
       false
     } else {
       true
     }
-  }
-
-  private def getSchemaAsDataType(schema: StructType, fieldName: String): DataType = {
-    schema(schema.getFieldIndex(fieldName).get).dataType
   }
 }
 

--- a/src/main/scala/org/apache/spark/sql/state/migration/StreamingAggregationMigrator.scala
+++ b/src/main/scala/org/apache/spark/sql/state/migration/StreamingAggregationMigrator.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 Jungtaek Lim "<kabhwan@gmail.com>"
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.state.migration
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.checkpoint.CheckpointUtil
+import org.apache.spark.sql.execution.streaming.state.StreamingAggregationStateManager
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.state.{StateInformationInCheckpoint, StateStoreDataSourceProvider}
+import org.apache.spark.sql.types.StructType
+
+class StreamingAggregationMigrator(spark: SparkSession) extends Logging {
+
+  def convertVersion1To2(
+      checkpointRoot: Path,
+      newCheckpointRoot: Path,
+      keySchema: StructType,
+      valueSchema: StructType): Unit = {
+    val stateInfo = new StateInformationInCheckpoint(spark).gatherInformation(checkpointRoot)
+
+    val stateVer = stateInfo.confs.getOrElse(SQLConf.STREAMING_AGGREGATION_STATE_FORMAT_VERSION.key,
+      StreamingAggregationStateManager.legacyVersion.toString).toInt
+
+    if (stateVer != 1) {
+      throw new IllegalArgumentException("Given checkpoint doesn't use state formation ver. 1 " +
+        s"for streaming aggregation! version: $stateVer")
+    }
+
+    val lastCommittedBatchId = stateInfo.lastCommittedBatchId match {
+      case Some(bid) => bid
+      case None => throw new IllegalArgumentException("No committed batch in given checkpoint.")
+    }
+
+    val addConf = Map(SQLConf.STREAMING_AGGREGATION_STATE_FORMAT_VERSION.key -> "2")
+    CheckpointUtil.createSavePoint(spark, checkpointRoot.toString, newCheckpointRoot.toString,
+      lastCommittedBatchId, addConf, excludeState = true)
+
+    val stateSchema = new StructType()
+      .add("key", keySchema)
+      .add("value", valueSchema)
+
+    val stateVersion = lastCommittedBatchId + 1
+    stateInfo.operators.foreach { op =>
+      val partitions = op.partitions
+      op.storeNames.map { storeName =>
+        val stateReadDf = spark.read
+          .format("state")
+          .schema(stateSchema)
+          .option(StateStoreDataSourceProvider.PARAM_CHECKPOINT_LOCATION,
+            new Path(checkpointRoot, "state").toString)
+          .option(StateStoreDataSourceProvider.PARAM_VERSION, stateVersion)
+          .option(StateStoreDataSourceProvider.PARAM_OPERATOR_ID, op.opId)
+          .option(StateStoreDataSourceProvider.PARAM_STORE_NAME, storeName)
+          .load()
+
+        logInfo(s"Schema of state format 1 (current): ${stateReadDf.schema.treeString}")
+
+        // This assumes only columns in key part are duplicated between key and value schema
+        val newValueSchema = valueSchema.filterNot(field => keySchema.contains(field))
+
+        val newValueColumns = newValueSchema.map("value." + _.name).mkString(",")
+        val selectExprs = Seq("key", s"struct($newValueColumns) AS value")
+
+        val modifiedDf = stateReadDf.selectExpr(selectExprs: _*)
+
+        logInfo(s"Schema of state format 2 (new): ${modifiedDf.schema.treeString}")
+
+        modifiedDf.write
+          .format("state")
+          .option(StateStoreDataSourceProvider.PARAM_CHECKPOINT_LOCATION,
+            new Path(newCheckpointRoot, "state").toString)
+          .option(StateStoreDataSourceProvider.PARAM_VERSION, stateVersion)
+          .option(StateStoreDataSourceProvider.PARAM_OPERATOR_ID, op.opId)
+          .option(StateStoreDataSourceProvider.PARAM_STORE_NAME, storeName)
+          .option(StateStoreDataSourceProvider.PARAM_NEW_PARTITIONS, partitions)
+          .save
+
+        logInfo(s"Migrated state (opId: ${op.opId}, storeName: ${storeName}, " +
+          s"partitions: ${partitions} from format 1 to 2")
+      }
+    }
+  }
+
+}
+

--- a/src/test/scala/org/apache/spark/sql/state/StateInformationInCheckpointSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/state/StateInformationInCheckpointSuite.scala
@@ -20,6 +20,7 @@ import org.apache.hadoop.fs.Path
 import org.scalatest.{Assertions, BeforeAndAfterAll}
 
 import org.apache.spark.sql.execution.streaming.state.{StateStore, StateStoreId}
+import org.apache.spark.sql.internal.SQLConf
 
 class StateInformationInCheckpointSuite
   extends StateStoreTest
@@ -45,6 +46,9 @@ class StateInformationInCheckpointSuite
       assert(operator.opId === 0)
       assert(operator.partitions === spark.sqlContext.conf.numShufflePartitions)
       assert(operator.storeNames === Seq(StateStoreId.DEFAULT_STORE_NAME))
+
+      assert(stateInfo.confs.get(SQLConf.SHUFFLE_PARTITIONS.key) ===
+        Some(operator.partitions.toString))
     }
   }
 
@@ -62,6 +66,9 @@ class StateInformationInCheckpointSuite
       assert(operator.opId === 0)
       assert(operator.partitions === spark.sqlContext.conf.numShufflePartitions)
       assert(operator.storeNames === Seq(StateStoreId.DEFAULT_STORE_NAME))
+
+      assert(stateInfo.confs.get(SQLConf.SHUFFLE_PARTITIONS.key) ===
+        Some(operator.partitions.toString))
     }
   }
 
@@ -81,6 +88,9 @@ class StateInformationInCheckpointSuite
       // NOTE: this verification couples with implementation details of streaming join
       assert(operator.storeNames.toSet === Set("left-keyToNumValues", "left-keyWithIndexToValue",
         "right-keyToNumValues", "right-keyWithIndexToValue"))
+
+      assert(stateInfo.confs.get(SQLConf.SHUFFLE_PARTITIONS.key) ===
+        Some(operator.partitions.toString))
     }
   }
 
@@ -98,6 +108,9 @@ class StateInformationInCheckpointSuite
       assert(operator.opId === 0)
       assert(operator.partitions === spark.sqlContext.conf.numShufflePartitions)
       assert(operator.storeNames === Seq(StateStoreId.DEFAULT_STORE_NAME))
+
+      assert(stateInfo.confs.get(SQLConf.SHUFFLE_PARTITIONS.key) ===
+        Some(operator.partitions.toString))
     }
   }
 }

--- a/src/test/scala/org/apache/spark/sql/state/StateStoreStreamingAggregationWriteSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/state/StateStoreStreamingAggregationWriteSuite.scala
@@ -67,10 +67,9 @@ class StateStoreStreamingAggregationWriteSuite
 
         // copy all contents except state to new checkpoint root directory
         // adjust number of shuffle partitions in prior to migrate state
+        val addConf = getAdditionalConfForMetadata(newShufflePartitions)
         CheckpointUtil.createSavePoint(spark, oldCpDir.getAbsolutePath,
-          newCpDir.getAbsolutePath, newLastBatchId,
-          newShufflePartitions = Some(newShufflePartitions),
-          excludeState = true)
+          newCpDir.getAbsolutePath, newLastBatchId, addConf, excludeState = true)
 
         stateReadDf.write
           .format("state")
@@ -102,6 +101,10 @@ class StateStoreStreamingAggregationWriteSuite
     }
   }
 
+  private def getAdditionalConfForMetadata(newShufflePartitions: Int) = {
+    Map(SQLConf.SHUFFLE_PARTITIONS.key -> newShufflePartitions.toString)
+  }
+
   test("rescale state from streaming aggregation - state format version 2") {
     withSQLConf(Seq(SQLConf.STREAMING_AGGREGATION_STATE_FORMAT_VERSION.key -> "2"): _*) {
       withTempCheckpoints { case (oldCpDir, newCpDir) =>
@@ -126,10 +129,9 @@ class StateStoreStreamingAggregationWriteSuite
 
         // copy all contents except state to new checkpoint root directory
         // adjust number of shuffle partitions in prior to migrate state
+        val addConf = getAdditionalConfForMetadata(newShufflePartitions)
         CheckpointUtil.createSavePoint(spark, oldCpDir.getAbsolutePath,
-          newCpDir.getAbsolutePath, newLastBatchId,
-          newShufflePartitions = Some(newShufflePartitions),
-          excludeState = true)
+          newCpDir.getAbsolutePath, newLastBatchId, addConf, excludeState = true)
 
         stateReadDf.write
           .format("state")
@@ -215,10 +217,9 @@ class StateStoreStreamingAggregationWriteSuite
 
         // copy all contents except state to new checkpoint root directory
         // adjust number of shuffle partitions in prior to migrate state
+        val addConf = getAdditionalConfForMetadata(newShufflePartitions)
         CheckpointUtil.createSavePoint(spark, oldCpDir.getAbsolutePath,
-          newCpDir.getAbsolutePath, newLastBatchId,
-          newShufflePartitions = Some(newShufflePartitions),
-          excludeState = true)
+          newCpDir.getAbsolutePath, newLastBatchId, addConf, excludeState = true)
 
         evolutionDf.write
           .format("state")
@@ -305,10 +306,9 @@ class StateStoreStreamingAggregationWriteSuite
 
         // copy all contents except state to new checkpoint root directory
         // adjust number of shuffle partitions in prior to migrate state
+        val addConf = getAdditionalConfForMetadata(newShufflePartitions)
         CheckpointUtil.createSavePoint(spark, oldCpDir.getAbsolutePath,
-          newCpDir.getAbsolutePath, newLastBatchId,
-          newShufflePartitions = Some(newShufflePartitions),
-          excludeState = true)
+          newCpDir.getAbsolutePath, newLastBatchId, addConf, excludeState = true)
 
         evolutionDf.write
           .format("state")

--- a/src/test/scala/org/apache/spark/sql/state/StreamingAggregationMigratorSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/state/StreamingAggregationMigratorSuite.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2019 Jungtaek Lim "<kabhwan@gmail.com>"
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.state
+
+import java.io.File
+
+import org.apache.hadoop.fs.Path
+import org.scalatest.{Assertions, BeforeAndAfterAll}
+
+import org.apache.spark.sql.{Row, SchemaUtil}
+import org.apache.spark.sql.catalyst.streaming.InternalOutputModes.Update
+import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.execution.streaming.state.StateStore
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.state.migration.StreamingAggregationMigrator
+import org.apache.spark.sql.types.StructType
+
+class StreamingAggregationMigratorSuite
+  extends StateStoreTest
+    with BeforeAndAfterAll
+    with Assertions {
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    StateStore.stop()
+  }
+
+  test("migrate streaming aggregation state format version 1 to 2") {
+    withTempCheckpoints { case (oldCpDir, newCpDir) =>
+      val oldCpPath = new Path(oldCpDir.getAbsolutePath)
+      val newCpPath = new Path(newCpDir.getAbsolutePath)
+
+      // run streaming aggregation query to state format version 1
+      withSQLConf(SQLConf.STREAMING_AGGREGATION_STATE_FORMAT_VERSION.key -> "1") {
+        runCompositeKeyStreamingAggregationQuery(oldCpDir.getAbsolutePath)
+      }
+
+      val stateSchema = getSchemaForCompositeKeyStreamingAggregationQuery(1)
+
+      val migrator = new StreamingAggregationMigrator(spark)
+      migrator.convertVersion1To2(
+        oldCpPath,
+        newCpPath,
+        SchemaUtil.getSchemaAsDataType(stateSchema, "key").asInstanceOf[StructType],
+        SchemaUtil.getSchemaAsDataType(stateSchema, "value").asInstanceOf[StructType])
+
+      val newStateInfo = new StateInformationInCheckpoint(spark).gatherInformation(newCpPath)
+      assert(newStateInfo.lastCommittedBatchId.isDefined,
+        "The checkpoint directory should contain committed batch!")
+
+      // check whether it's running well with new checkpoint
+
+      // read state with new expected state schema (state format version 2)
+      val newStateSchema = getSchemaForCompositeKeyStreamingAggregationQuery(2)
+
+      // we assume operator id = 0, store_name = default
+      val stateReadDf = spark.read
+        .format("state")
+        .schema(newStateSchema)
+        .option(StateStoreDataSourceProvider.PARAM_CHECKPOINT_LOCATION,
+          new File(newCpDir, "state").getAbsolutePath)
+        .option(StateStoreDataSourceProvider.PARAM_VERSION,
+          newStateInfo.lastCommittedBatchId.get + 1)
+        .option(StateStoreDataSourceProvider.PARAM_OPERATOR_ID, 0)
+        .load()
+
+      checkAnswer(
+        stateReadDf
+          .selectExpr("key.groupKey AS key_groupKey", "key.fruit AS key_fruit",
+            "value.cnt AS value_cnt", "value.sum AS value_sum", "value.max AS value_max",
+            "value.min AS value_min"),
+        Seq(
+          Row(0, "Apple", 2, 6, 6, 0),
+          Row(1, "Banana", 3, 9, 7, 1),
+          Row(0, "Strawberry", 3, 12, 8, 2),
+          Row(1, "Apple", 3, 15, 9, 3),
+          Row(0, "Banana", 2, 14, 10, 4),
+          Row(1, "Strawberry", 1, 5, 5, 5)
+        )
+      )
+
+      // rerun streaming query from migrated checkpoint
+      verifyContinueRunCompositeKeyStreamingAggregationQuery(newCpPath.toString)
+    }
+  }
+
+
+  private def verifyContinueRunCompositeKeyStreamingAggregationQuery(
+      checkpointRoot: String): Unit = {
+    import org.apache.spark.sql.functions._
+    import testImplicits._
+
+    val inputData = MemoryStream[Int]
+
+    val aggregated = inputData.toDF()
+      .selectExpr("value", "value % 2 AS groupKey",
+        "(CASE value % 3 WHEN 0 THEN 'Apple' WHEN 1 THEN 'Banana' ELSE 'Strawberry' END) AS fruit")
+      .groupBy($"groupKey", $"fruit")
+      .agg(
+        count("*").as("cnt"),
+        sum("value").as("sum"),
+        max("value").as("max"),
+        min("value").as("min")
+      )
+      .as[(Int, String, Long, Long, Int, Int)]
+
+    // batch 0
+    inputData.addData(0 to 5)
+    // batch 1
+    inputData.addData(6 to 10)
+    // batch 2
+    inputData.addData(3, 2, 1)
+
+    testStream(aggregated, Update)(
+      StartStream(checkpointLocation = checkpointRoot),
+      // batch 3
+      AddData(inputData, 3, 2, 1),
+      CheckLastBatch(
+        (1, "Banana", 4, 10, 7, 1), // 1, 7, 1, 1
+        (0, "Strawberry", 4, 14, 8, 2), // 2, 8, 2, 2
+        (1, "Apple", 4, 18, 9, 3) // 3, 9, 3, 3
+      )
+    )
+  }
+}


### PR DESCRIPTION
This patch introduces `StreamingAggregationMigrator` to help migration streaming aggregation state from 1 to 2. Here's the target:

* query used streaming aggregation (mostly `agg()`)
* the query ran before Spark 2.4.0 for the first time, and checkpoint is kept

Schema of state key/value should be provided, so I don't create CLI app for this. When Spark will contain state schema, we can leverage it and finally make this to CLI app.

Note that it migrates state for latest committed batch and it's not done per batch. You can't roll back to previous batch and need to start with latest committed batch. (It will be picked up from Spark automatically.)