### PR TITLE
ISSUE-4 Address state regarding flatMapGroupsWithState

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The features we provide as of now are:
 As this project leverages Spark Structured Streaming's interfaces, and doesn't deal with internal
 (e.g. the structure of state file for HDFS state store), the performance may be suboptimal.
 
-For now, from the most parts, only states from Streaming Aggregation query (`groupBy().agg()`) are supported.
+For now, from the most parts, states from Streaming Aggregation query (`groupBy().agg()`) and (Flat)MapGroupsWithState are supported.
 
 ## Disclaimer
 


### PR DESCRIPTION
This patch just modifies README.md to notice the tool also supports (flat)MapGroupsWithState, since it's already supported.

Quoting my comment in #4 :

> I guess it can be simply covered, since flatMapGroupsWithState puts object as decoded row (with columns). Now it's just related to how to know state schema, and we support extracting state schema from flatMapGroupsWithState query (#17), so I think we support flatMapGroupsWithState.

closes #4 