### PR TITLE
MINOR Code cleanup (deduplicate) in tests

### DIFF
--- a/src/test/scala/org/apache/spark/sql/state/StateStoreReaderOperatorParamExtractorSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/state/StateStoreReaderOperatorParamExtractorSuite.scala
@@ -16,24 +16,16 @@
 
 package org.apache.spark.sql.state
 
-import java.sql.Timestamp
-
 import org.apache.hadoop.fs.Path
 import org.scalatest.{Assertions, BeforeAndAfterAll}
 
-import org.apache.spark.sql.Dataset
-import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.execution.streaming.state.{StateStore, StateStoreId}
-import org.apache.spark.sql.streaming.{GroupState, GroupStateTimeout}
 import org.apache.spark.sql.types.StructType
 
 class StateStoreReaderOperatorParamExtractorSuite
   extends StateStoreTest
     with BeforeAndAfterAll
     with Assertions {
-
-  import testImplicits._
-  import org.apache.spark.sql.functions._
 
   override def afterAll(): Unit = {
     super.afterAll()
@@ -49,7 +41,7 @@ class StateStoreReaderOperatorParamExtractorSuite
       assert(stateInfo.operators.length === 1)
       // other validation of stateInfo is covered by StateInformationCheckpointSuite
 
-      val query = getCompositeKeyStreamingQuery
+      val query = getCompositeKeyStreamingAggregationQuery
 
       val schemaInfo = new StateSchemaExtractor(spark).extract(query.toDF)
       assert(schemaInfo.length === 1)
@@ -122,76 +114,5 @@ class StateStoreReaderOperatorParamExtractorSuite
         opParam.lastStateVersion.contains(2) && opParam.opId == 0 && opParam.stateSchema.isEmpty
       }
     }
-  }
-
-  private def getCompositeKeyStreamingQuery: Dataset[(Int, String, Long, Long, Int, Int)] = {
-    val inputData = MemoryStream[Int]
-
-    // This is borrowed from StateStoreTest, runCompositeKeyStreamingAggregationQuery
-    // so we can get schema information from getSchemaForCompositeKeyStreamingAggregationQuery
-    inputData.toDF()
-      .selectExpr("value", "value % 2 AS groupKey",
-        "(CASE value % 3 WHEN 0 THEN 'Apple' WHEN 1 THEN 'Banana' ELSE 'Strawberry' END) AS fruit")
-      .groupBy($"groupKey", $"fruit")
-      .agg(
-        count("*").as("cnt"),
-        sum("value").as("sum"),
-        max("value").as("max"),
-        min("value").as("min")
-      )
-      .as[(Int, String, Long, Long, Int, Int)]
-  }
-
-  private def getFlatMapGroupsWithStateQuery: Dataset[(String, Int, Long)] = {
-    val inputData = MemoryStream[(String, Long)]
-
-    val events = inputData.toDF()
-      .as[(String, Timestamp)]
-      .flatMap { case (line, timestamp) =>
-        line.split(" ").map(word => Event(sessionId = word, timestamp))
-      }
-
-    val sessionUpdates = events
-      .groupByKey(event => event.sessionId)
-      .mapGroupsWithState[SessionInfo, SessionUpdate](GroupStateTimeout.ProcessingTimeTimeout) {
-
-      case (sessionId: String, events: Iterator[Event], state: GroupState[SessionInfo]) =>
-        if (state.hasTimedOut) {
-          val finalUpdate =
-            SessionUpdate(sessionId, state.get.durationMs, state.get.numEvents, expired = true)
-          state.remove()
-          finalUpdate
-        } else {
-          val timestamps = events.map(_.timestamp.getTime).toSeq
-          val updatedSession = if (state.exists) {
-            val oldSession = state.get
-            SessionInfo(
-              oldSession.numEvents + timestamps.size,
-              oldSession.startTimestampMs,
-              math.max(oldSession.endTimestampMs, timestamps.max))
-          } else {
-            SessionInfo(timestamps.size, timestamps.min, timestamps.max)
-          }
-          state.update(updatedSession)
-
-          state.setTimeoutDuration("10 seconds")
-          SessionUpdate(sessionId, state.get.durationMs, state.get.numEvents, expired = false)
-        }
-    }
-
-    sessionUpdates.map(si => (si.id, si.numEvents, si.durationMs))
-  }
-
-  private def getStreamingJoinQuery: Dataset[(Int, String, Int, String)] = {
-    val inputData = MemoryStream[Int]
-
-    val df = inputData.toDF()
-      .selectExpr("value", "CASE value % 2 WHEN 0 THEN 'even' ELSE 'odd' END AS isEven")
-    val df2 = df.selectExpr("value AS value2", "iseven AS isEven2")
-      .where("value % 3 != 0")
-
-    df.join(df2, expr("value == value2"))
-      .selectExpr("value", "iseven", "value2", "iseven2")
-      .as[(Int, String, Int, String)]
   }
 }

--- a/src/test/scala/org/apache/spark/sql/state/StateStoreStreamingAggregationWriteSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/state/StateStoreStreamingAggregationWriteSuite.scala
@@ -356,17 +356,7 @@ class StateStoreStreamingAggregationWriteSuite
     import testImplicits._
 
     val inputData = MemoryStream[Int]
-
-    val aggregated = inputData.toDF()
-      .selectExpr("value", "value % 10 AS groupKey")
-      .groupBy($"groupKey")
-      .agg(
-        count("*").as("cnt"),
-        sum("value").as("sum"),
-        max("value").as("max"),
-        min("value").as("min")
-      )
-      .as[(Int, Long, Long, Int, Int)]
+    val aggregated = getLargeDataStreamingAggregationQuery(inputData)
 
     // batch 0
     inputData.addData(0 until 20)

--- a/src/test/scala/org/apache/spark/sql/state/StreamingAggregationMigratorSuite.scala
+++ b/src/test/scala/org/apache/spark/sql/state/StreamingAggregationMigratorSuite.scala
@@ -106,18 +106,7 @@ class StreamingAggregationMigratorSuite
     import testImplicits._
 
     val inputData = MemoryStream[Int]
-
-    val aggregated = inputData.toDF()
-      .selectExpr("value", "value % 2 AS groupKey",
-        "(CASE value % 3 WHEN 0 THEN 'Apple' WHEN 1 THEN 'Banana' ELSE 'Strawberry' END) AS fruit")
-      .groupBy($"groupKey", $"fruit")
-      .agg(
-        count("*").as("cnt"),
-        sum("value").as("sum"),
-        max("value").as("max"),
-        min("value").as("min")
-      )
-      .as[(Int, String, Long, Long, Int, Int)]
+    val aggregated = getCompositeKeyStreamingAggregationQuery(inputData)
 
     // batch 0
     inputData.addData(0 to 5)


### PR DESCRIPTION
This patch centralizes the redundant parts of code to StateStoreTest and deduplicates others.