### PR TITLE
Fix the performance issue via initializing RowEncoder only once

### DIFF
--- a/src/main/scala/net/heartsavior/spark/sql/checkpoint/CheckpointUtil.scala
+++ b/src/main/scala/net/heartsavior/spark/sql/checkpoint/CheckpointUtil.scala
@@ -76,7 +76,7 @@ object CheckpointUtil {
     val offsetLog = new OffsetSeqLog(sparkSession, new Path(dst, "offsets").toString)
     val logForBatch = offsetLog.get(newLastBatchId) match {
       case Some(log) => log
-      case None => throw new IllegalStateException("offset log for batch should be exist")
+      case None => throw new IllegalStateException("offset log for batch should exist")
     }
 
     val newMetadata = logForBatch.metadata match {

--- a/src/main/scala/net/heartsavior/spark/sql/state/StateStoreDataSourceProvider.scala
+++ b/src/main/scala/net/heartsavior/spark/sql/state/StateStoreDataSourceProvider.scala
@@ -73,7 +73,7 @@ class StateStoreDataSourceProvider
 
     new StateStoreRelation(sqlContext.sparkSession, keySchema,
       valueSchema, checkpointLocation, version, operatorId,
-      storeName, parameters)
+      storeName)
   }
 
   override def createRelation(

--- a/src/main/scala/net/heartsavior/spark/sql/state/StateStoreReaderRDD.scala
+++ b/src/main/scala/net/heartsavior/spark/sql/state/StateStoreReaderRDD.scala
@@ -67,7 +67,8 @@ class StateStoreReaderRDD(
           indexOrdinal = None, version = batchId, storeConf = storeConf,
           hadoopConf = hadoopConfBroadcastWrapper.broadcastedConf.value.value)
 
-        val encoder = RowEncoder(SchemaUtil.schema(keySchema, valueSchema)).resolveAndBind()
+        val encoder = RowEncoder(SchemaUtil.keyValuePairSchema(keySchema, valueSchema))
+          .resolveAndBind()
         val iter = store.iterator().map { pair =>
           val row = new GenericInternalRow(Array(pair.key, pair.value).asInstanceOf[Array[Any]])
           encoder.fromRow(row)

--- a/src/main/scala/net/heartsavior/spark/sql/state/StateStoreReaderRDD.scala
+++ b/src/main/scala/net/heartsavior/spark/sql/state/StateStoreReaderRDD.scala
@@ -39,7 +39,7 @@ class StateStorePartition(
 }
 
 /**
- * An RDD that reads (key, value) pair of state and provides these pairs.
+ * An RDD that reads (key, value) pairs of state and provides rows having columns (key, value).
  */
 class StateStoreReaderRDD(
     session: SparkSession,

--- a/src/main/scala/net/heartsavior/spark/sql/state/StateStoreReaderRDD.scala
+++ b/src/main/scala/net/heartsavior/spark/sql/state/StateStoreReaderRDD.scala
@@ -20,12 +20,14 @@ import java.util.UUID
 
 import scala.util.Try
 
+import net.heartsavior.spark.sql.util.SchemaUtil
 import org.apache.hadoop.fs.{Path, PathFilter}
 
 import org.apache.spark.{Partition, TaskContext}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.expressions.UnsafeRow
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.execution.streaming.state.{StateStore, StateStoreConf, StateStoreId, StateStoreProviderId}
 import org.apache.spark.sql.hack.SerializableConfigurationWrapper
 import org.apache.spark.sql.types.StructType
@@ -47,14 +49,14 @@ class StateStoreReaderRDD(
     batchId: Long,
     operatorId: Long,
     storeName: String)
-  extends RDD[(UnsafeRow, UnsafeRow)](session.sparkContext, Nil) {
+  extends RDD[Row](session.sparkContext, Nil) {
 
   private val storeConf = new StateStoreConf(session.sessionState.conf)
 
   // A Hadoop Configuration can be about 10 KB, which is pretty big, so broadcast it
   private val hadoopConfBroadcastWrapper = new SerializableConfigurationWrapper(session)
 
-  override def compute(split: Partition, context: TaskContext): Iterator[(UnsafeRow, UnsafeRow)] = {
+  override def compute(split: Partition, context: TaskContext): Iterator[Row] = {
     split match {
       case p: StateStorePartition =>
         val stateStoreId = StateStoreId(stateCheckpointRootLocation, operatorId,
@@ -65,7 +67,11 @@ class StateStoreReaderRDD(
           indexOrdinal = None, version = batchId, storeConf = storeConf,
           hadoopConf = hadoopConfBroadcastWrapper.broadcastedConf.value.value)
 
-        val iter = store.iterator().map(pair => (pair.key, pair.value))
+        val encoder = RowEncoder(SchemaUtil.schema(keySchema, valueSchema)).resolveAndBind()
+        val iter = store.iterator().map { pair =>
+          val row = new GenericInternalRow(Array(pair.key, pair.value).asInstanceOf[Array[Any]])
+          encoder.fromRow(row)
+        }
 
         // close state store provider after using
         StateStore.unload(stateStoreProviderId)

--- a/src/main/scala/net/heartsavior/spark/sql/state/StateStoreRelation.scala
+++ b/src/main/scala/net/heartsavior/spark/sql/state/StateStoreRelation.scala
@@ -35,8 +35,8 @@ class StateStoreRelation(
     stateCheckpointLocation: String,
     batchId: Int,
     operatorId: Int,
-    storeName: String = StateStoreId.DEFAULT_STORE_NAME,
-    sourceOptions: Map[String, String]) extends BaseRelation with TableScan with Logging {
+    storeName: String = StateStoreId.DEFAULT_STORE_NAME)
+  extends BaseRelation with TableScan with Logging {
 
   override def sqlContext: SQLContext = session.sqlContext
 

--- a/src/main/scala/net/heartsavior/spark/sql/state/StateStoreRelation.scala
+++ b/src/main/scala/net/heartsavior/spark/sql/state/StateStoreRelation.scala
@@ -40,7 +40,7 @@ class StateStoreRelation(
 
   override def sqlContext: SQLContext = session.sqlContext
 
-  override def schema: StructType = SchemaUtil.schema(keySchema, valueSchema)
+  override def schema: StructType = SchemaUtil.keyValuePairSchema(keySchema, valueSchema)
 
   override def buildScan(): RDD[Row] = {
     val resolvedCpLocation = {

--- a/src/main/scala/net/heartsavior/spark/sql/state/StateStoreWriter.scala
+++ b/src/main/scala/net/heartsavior/spark/sql/state/StateStoreWriter.scala
@@ -52,7 +52,7 @@ class StateStoreWriter(
       val checkpointPath = new Path(stateCheckpointLocation)
       val fs = checkpointPath.getFileSystem(session.sessionState.newHadoopConf())
       if (fs.exists(checkpointPath)) {
-        throw new IllegalStateException(s"Checkpoint location should not be exist. " +
+        throw new IllegalStateException(s"Checkpoint location should not exist. " +
           s"Path: $checkpointPath")
       }
       fs.mkdirs(checkpointPath)

--- a/src/main/scala/net/heartsavior/spark/sql/util/SchemaUtil.scala
+++ b/src/main/scala/net/heartsavior/spark/sql/util/SchemaUtil.scala
@@ -23,4 +23,8 @@ object SchemaUtil {
   def getSchemaAsDataType(schema: StructType, fieldName: String): DataType = {
     schema(SparkSqlHack.getFieldIndex(schema, fieldName).get).dataType
   }
+
+  def schema(keySchema: StructType, valueSchema: StructType): StructType = new StructType()
+    .add("key", StructType(keySchema.fields), nullable = false)
+    .add("value", StructType(valueSchema.fields), nullable = false)
 }

--- a/src/main/scala/net/heartsavior/spark/sql/util/SchemaUtil.scala
+++ b/src/main/scala/net/heartsavior/spark/sql/util/SchemaUtil.scala
@@ -24,7 +24,8 @@ object SchemaUtil {
     schema(SparkSqlHack.getFieldIndex(schema, fieldName).get).dataType
   }
 
-  def schema(keySchema: StructType, valueSchema: StructType): StructType = new StructType()
-    .add("key", StructType(keySchema.fields), nullable = false)
-    .add("value", StructType(valueSchema.fields), nullable = false)
+  def keyValuePairSchema(keySchema: StructType, valueSchema: StructType): StructType =
+    new StructType()
+      .add("key", StructType(keySchema.fields), nullable = false)
+      .add("value", StructType(valueSchema.fields), nullable = false)
 }


### PR DESCRIPTION
Fixes #35 .

Also, unrelated, in `StateStoreRelation.scala` you have
```scala

class StateStoreRelation(
    session: SparkSession,
    keySchema: StructType,
    valueSchema: StructType,
    stateCheckpointLocation: String,
    batchId: Int,
    operatorId: Int,
    storeName: String = StateStoreId.DEFAULT_STORE_NAME,
    sourceOptions: Map[String, String]) extends BaseRelation with TableScan with Logging
```

but `sourceOptions` is unused. Should that be fixed?